### PR TITLE
fix: default config did not apply on external files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
                     "type": "array",
                     "description": "Glob patterns to match files that should have block comments treated as multiple line comments ",
                     "default": [
-                        "**/*.xml",
-                        "**/*.html",
-                        "**/*.css",
-                        "**/*.md"
+                        "*.xml",
+                        "*.html",
+                        "*.css",
+                        "*.md"
                     ]
                 }
             }


### PR DESCRIPTION
If we opened file outside of the current project, the pattern used in the default configuration did not matched it